### PR TITLE
Extend maximum offset limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ assert_eq!(
 
 - The value must be represented as a 31 bit unsigned integer, typed `u32`.
   - Yada uses the most significant bit (MSB) as a flag to distinguish between a value node and others.
-- The offset of an double-array node is 23 bit wide, so it can only represent up to
- ~8.3M nodes.
-  - It means this limitation results in the size upper bound ~33 MB of double-arrays.
+- The offset of an double-array node is 29 bits wide, so it can represent up to
+ ~536M nodes.
+  - It means this limitation results in the size upper bound ~2GB of double-arrays.
 
 ## License
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -177,7 +177,7 @@ impl DoubleArrayBuilder {
         // upper 24 bits should be 0
         assert_eq!(parent_unit.offset(), 0);
         assert!(!parent_unit.has_leaf());
-        parent_unit.set_offset(offset);
+        parent_unit.set_offset(offset ^ unit_id as u32); // store the relative offset to the index
         parent_unit.set_has_leaf(has_leaf);
 
         // populate label or associated value to children node

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -133,4 +133,22 @@ mod tests {
         unit.set_value(1 << 31);
         assert_eq!(unit.value(), 0);
     }
+
+    #[test]
+    fn test_label() {
+        let unit = Unit::new();
+        assert_eq!(unit.label(), 0);
+
+        let mut unit = Unit::new();
+        unit.set_label(0);
+        assert_eq!(unit.label(), 0);
+
+        let mut unit = Unit::new();
+        unit.set_label(1);
+        assert_eq!(unit.label(), 1);
+
+        let mut unit = Unit::new();
+        unit.set_label(255);
+        assert_eq!(unit.label(), 255);
+    }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -151,4 +151,18 @@ mod tests {
         unit.set_label(255);
         assert_eq!(unit.label(), 255);
     }
+
+    #[test]
+    fn test_offset() {
+        let unit = Unit::new();
+        assert_eq!(unit.offset(), 0);
+
+        let mut unit = Unit::new();
+        unit.set_offset(0);
+        assert_eq!(unit.offset(), 0);
+
+        let mut unit = Unit::new();
+        unit.set_offset(1);
+        assert_eq!(unit.offset(), 1);
+    }
 }


### PR DESCRIPTION
This PR relaxes the offset bit-width limitation from 22 bits to 29 bits. Therefore, the maximum size of a double array can be ~2GB.

`set_offset` stores the upper 21 bits of the offset (29 bits) and ignore the lower 8 bits if the offset is greater than 21 bits.
We use the 10th bit of the node (32 bits) as an offset extension flag to distinguish the offset was extended or not.

Also, this PR will change the stored offset to the "relative" offset from the position of the node.
The relative offset will be calculated by `position ^ offset`. The offset will be restored in the same way, `position ^ offset` when it will be retrieved.