### PR TITLE
Use get_uncecked to get a double array unit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,12 @@ where
     }
 
     fn get_unit(&self, index: usize) -> Option<Unit> {
-        let b = &self.0[index * UNIT_SIZE..(index + 1) * UNIT_SIZE];
+        let b = unsafe {
+            // This unsafe method call does not lead unexpected transitions
+            // when a double array was built properly.
+            self.0
+                .get_unchecked(index * UNIT_SIZE..(index + 1) * UNIT_SIZE)
+        };
         match b.try_into() {
             Ok(bytes) => Some(Unit::from_u32(u32::from_le_bytes(bytes))),
             Err(_) => None,


### PR DESCRIPTION
This PR makes it access a slice of the double array through the `get_unchecked` method.

I performed benchmarks between `0.4.0` and this branch alternately.
The benchmark result shows significant performance improvements on `exact_match_search` and `common_prefix_search`.

<details>
<summary>Raw benchmark results by Criterion.rs.</summary>

yada 0.4.0:

```
search/random/ipadic/exact_match_search                                                                           
                        time:   [40.765 ms 42.741 ms 44.922 ms]
Found 2 outliers among 30 measurements (6.67%)
  2 (6.67%) high mild
search/random/ipadic/common_prefix_search                                                                           
                        time:   [53.027 ms 55.222 ms 57.613 ms]
```

this branch:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [34.972 ms 35.395 ms 35.850 ms]
                        change: [-21.348% -17.186% -13.011%] (p = 0.00 < 0.05)
                        Performance has improved.
search/random/ipadic/common_prefix_search                                                                           
                        time:   [41.711 ms 42.672 ms 43.895 ms]
                        change: [-26.291% -22.726% -18.771%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  1 (3.33%) high mild
  2 (6.67%) high severe
```

yada 0.4.0:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [44.053 ms 46.754 ms 49.841 ms]
                        change: [+24.847% +32.091% +40.958%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 30 measurements (16.67%)
  4 (13.33%) high mild
  1 (3.33%) high severe
search/random/ipadic/common_prefix_search                                                                           
                        time:   [50.498 ms 52.809 ms 55.242 ms]
                        change: [+17.293% +23.755% +30.250%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

this branch:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [35.291 ms 35.603 ms 35.919 ms]
                        change: [-28.535% -23.850% -19.096%] (p = 0.00 < 0.05)
                        Performance has improved.
search/random/ipadic/common_prefix_search                                                                           
                        time:   [42.583 ms 43.853 ms 45.483 ms]
                        change: [-21.380% -16.959% -12.005%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  1 (3.33%) high mild
  2 (6.67%) high severe
```

yada 0.4.0:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [39.363 ms 40.443 ms 41.741 ms]
                        change: [+10.451% +13.594% +16.997%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 30 measurements (13.33%)
  1 (3.33%) high mild
  3 (10.00%) high severe
search/random/ipadic/common_prefix_search                                                                           
                        time:   [44.538 ms 44.959 ms 45.433 ms]
                        change: [-1.2826% +2.5204% +5.7510%] (p = 0.18 > 0.05)
                        No change in performance detected.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
```

this branch:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [34.192 ms 34.591 ms 35.007 ms]
                        change: [-17.200% -14.469% -11.847%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  2 (6.67%) high mild
search/random/ipadic/common_prefix_search                                                                           
                        time:   [41.160 ms 41.631 ms 42.156 ms]
                        change: [-8.7867% -7.4020% -5.9654%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 30 measurements (13.33%)
  4 (13.33%) high mild
```

yada 0.4.0:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [44.074 ms 45.502 ms 46.956 ms]
                        change: [+26.866% +31.541% +36.079%] (p = 0.00 < 0.05)
                        Performance has regressed.
search/random/ipadic/common_prefix_search                                                                           
                        time:   [49.728 ms 51.418 ms 53.174 ms]
                        change: [+19.187% +23.510% +28.112%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

this branch:
```
search/random/ipadic/exact_match_search                                                                           
                        time:   [35.246 ms 36.016 ms 36.889 ms]
                        change: [-23.771% -20.847% -17.609%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  2 (6.67%) high mild
  1 (3.33%) high severe
search/random/ipadic/common_prefix_search                                                                           
                        time:   [42.156 ms 43.747 ms 45.676 ms]
                        change: [-19.124% -14.920% -10.126%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 30 measurements (13.33%)
  2 (6.67%) high mild
  2 (6.67%) high severe
```
</details>