### PR TITLE
Add inline

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ where
         }
     }
 
+    #[inline(always)]
     fn get_unit(&self, index: usize) -> Option<Unit> {
         let b = &self.0[index * UNIT_SIZE..(index + 1) * UNIT_SIZE];
         match b.try_into() {
@@ -109,6 +110,7 @@ where
 {
     type Item = (u32, usize);
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         while self.key_pos < self.key.len() {
             let unit = self.double_array.get_unit(self.unit_id)?;


### PR DESCRIPTION
I added `#[inline(always)]` to `DoubleArray::get_unit` and `CommonPrefixSearch::Iterator::next` which are called frequently.

With my environment (GCP n1-standard-4, vCPU x 4, 15GB RAM), the speed of `common_prefix_search` was improved by up to 23%.

```
$ cargo bench
search/sorted/ipadic/common_prefix_search                                                                           
                        time:   [15.980 ms 16.202 ms 16.452 ms]
                        change: [-25.170% -23.759% -22.334%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  3 (10.00%) high mild

search/sorted/unidic/common_prefix_search                                                                           
                        time:   [29.473 ms 29.854 ms 30.272 ms]
                        change: [-24.992% -23.507% -21.909%] (p = 0.00 < 0.05)
                        Performance has improved.

search/sorted/kodic/common_prefix_search                                                                           
                        time:   [37.803 ms 38.410 ms 39.197 ms]
                        change: [-23.490% -21.791% -19.837%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  1 (3.33%) high mild
  1 (3.33%) high severe

search/random/ipadic/common_prefix_search                                                                           
                        time:   [50.556 ms 51.261 ms 52.074 ms]
                        change: [-18.472% -15.720% -13.305%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  2 (6.67%) high mild
  1 (3.33%) high severe

search/random/unidic/common_prefix_search                                                                           
                        time:   [107.54 ms 109.09 ms 110.73 ms]
                        change: [-17.055% -15.136% -13.147%] (p = 0.00 < 0.05)
                        Performance has improved.

search/random/kodic/common_prefix_search                                                                          
                        time:   [171.22 ms 173.99 ms 177.03 ms]
                        change: [-15.623% -13.883% -11.864%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  2 (6.67%) high mild
```