### PR TITLE
Check if unit is not leaf node before comparing label

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@ where
             node_pos = (unit.offset() ^ node_pos as u32 ^ c as u32) as UnitID;
             unit = self.get_unit(node_pos)?;
 
-            if c != unit.label() as u8 {
+            if unit.label() != c as u32 {
                 return None;
             }
         }


### PR DESCRIPTION
### Problem
In certain situation, the program may panic when calling `da.exact_match_search()` with the following error:
```
thread '<unnamed>' panicked at [.../yada-0.5.0/src/lib.rs:37:13]:
assertion failed: !unit.is_leaf()
stack backtrace:
   0: _rust_begin_unwind
   2: core::panicking::panic
   1: core::panicking::panic_fmt
   3: yada::DoubleArray<T>::exact_match_search
``` 

### Why does it happen?

Let `a`, `b`, `c` some node, and `x`, `y` some character.
While traversing the tree, you move from node `a` by char `x`, and such node does not exist. But the space is filled by another node `c` which is a node you get to from node `b` by char `y`. If `c` is a leaf node, and value of `c`'s last 8 bits is the numerical value of char `x`, then in the modified line of code `unit.label() as u8` equals `x`.
Then in next iteration, the program panics at `assert!(!unit.is_leaf());`

### Code to reproduce
```rust
use yada::DoubleArray;
use yada::builder::DoubleArrayBuilder;

let mut builder = DoubleArrayBuilder::new();
let keys = vec!["a", "ab", "de"];
let mut keysets: Vec<(&[u8], u32)> = vec![];
for key in keys {
    keysets.push((key.as_bytes(), 97));
}
let da_bytes = builder.build_from_keyset(&keysets).unwrap();
let da = DoubleArray::new(da_bytes);
da.exact_match_search("dasss")
```

### Fix
Changing to `c as u32` as done for `common_prefix_search()` fixes the issue, as `unit.label()` returns a value bigger than 255 if `unit` is a leaf node. Therefore if `unit` is a leaf node, `unit.label() != c as u32` for all c. 