### PR TITLE
Verify DoubleArray input on construction

### DIFF
--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -192,7 +192,7 @@ fn add_search_bench_functions(
     });
     group.bench_function("exact_match_search", |b| {
         let da_bytes = DoubleArrayBuilder::build(keyset_build.as_slice()).unwrap();
-        let da = DoubleArray::new(da_bytes);
+        let da = DoubleArray::new(da_bytes).unwrap();
         b.iter(|| {
             for (key, _) in keyset_search.iter() {
                 let value = da.exact_match_search(key);
@@ -204,7 +204,7 @@ fn add_search_bench_functions(
     });
     group.bench_function("common_prefix_search", |b| {
         let da_bytes = DoubleArrayBuilder::build(keyset_build.as_slice()).unwrap();
-        let da = DoubleArray::new(da_bytes);
+        let da = DoubleArray::new(da_bytes).unwrap();
         b.iter(|| {
             for (key, _) in keyset_search.as_slice() {
                 let values = da.common_prefix_search(key);

--- a/examples/build_and_search.rs
+++ b/examples/build_and_search.rs
@@ -19,7 +19,7 @@ fn main() {
     assert!(da_bytes.is_some());
 
     // create a double-array trie instance
-    let da = DoubleArray::new(da_bytes.unwrap());
+    let da = DoubleArray::new(da_bytes.unwrap()).expect("Valid double array");
 
     // exact match search
     for (key, value) in keyset {

--- a/examples/load_from_file.rs
+++ b/examples/load_from_file.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     assert!(da_bytes.is_some());
 
     // create a double-array trie instance
-    let da = DoubleArray::new(da_bytes.unwrap());
+    let da = DoubleArray::new(da_bytes.unwrap()).expect("Valid double array");
 
     // save to file
     let mut file = File::create(filename)?;
@@ -34,7 +34,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut file = File::open(filename)?;
     let mut buf = Vec::new();
     let _ = file.read_to_end(&mut buf)?;
-    let da = DoubleArray::new(buf);
+    let da = DoubleArray::new(buf).expect("Valid double array");
 
     // test search
     for (key, value) in keyset.iter() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,7 @@ use crate::unit::{Unit, UnitID};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 
-const BLOCK_SIZE: usize = 256;
+pub(crate) const BLOCK_SIZE: usize = 256;
 const NUM_TARGET_BLOCKS: i32 = 16; // the number of target blocks to find offsets
 const INVALID_NEXT: u8 = 0; // 0 means that there is no next unused unit
 const INVALID_PREV: u8 = 255; // 255 means that there is no previous unused unit

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,10 +34,13 @@ pub enum YadaError {
     /// The input double-array trie byte length is not aligned to the unit size.
     UnalignedDoubleArray { len: usize, unit_size: usize },
 
+    /// The input double-array trie unit length is not aligned to the block size.
+    UnalignedDoubleArrayBlocks { num_units: usize, block_size: usize },
+
     /// A unit in the input double-array trie refers to a child unit outside the input.
     InvalidDoubleArrayUnit {
         index: usize,
-        child_index: usize,
+        offset: usize,
         num_units: usize,
     },
 }
@@ -61,13 +64,20 @@ impl fmt::Display for YadaError {
                 f,
                 "double-array trie byte length ({len}) must be a multiple of unit size ({unit_size})"
             ),
+            Self::UnalignedDoubleArrayBlocks {
+                num_units,
+                block_size,
+            } => write!(
+                f,
+                "double-array trie unit length ({num_units}) must be a multiple of block size ({block_size})"
+            ),
             Self::InvalidDoubleArrayUnit {
                 index,
-                child_index,
+                offset,
                 num_units,
             } => write!(
                 f,
-                "double-array trie unit at index {index} can refer to child index {child_index}, but num_units is {num_units}"
+                "double-array trie unit at index {index} can refer to offset {offset}, but num_units is {num_units}"
             ),
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,19 @@ pub enum YadaError {
 
     /// The resulting trie exceeds the maximum number of units.
     TooManyUnits { max: u32 },
+
+    /// The input double-array trie is empty.
+    EmptyDoubleArray,
+
+    /// The input double-array trie byte length is not aligned to the unit size.
+    UnalignedDoubleArray { len: usize, unit_size: usize },
+
+    /// A unit in the input double-array trie refers to a child unit outside the input.
+    InvalidDoubleArrayUnit {
+        index: usize,
+        child_index: usize,
+        num_units: usize,
+    },
 }
 
 impl fmt::Display for YadaError {
@@ -43,6 +56,19 @@ impl fmt::Display for YadaError {
             Self::TooManyUnits { max } => {
                 write!(f, "num_units must be no greater than {max}")
             }
+            Self::EmptyDoubleArray => write!(f, "double-array trie must not be empty"),
+            Self::UnalignedDoubleArray { len, unit_size } => write!(
+                f,
+                "double-array trie byte length ({len}) must be a multiple of unit size ({unit_size})"
+            ),
+            Self::InvalidDoubleArrayUnit {
+                index,
+                child_index,
+                num_units,
+            } => write!(
+                f,
+                "double-array trie unit at index {index} can refer to child index {child_index}, but num_units is {num_units}"
+            ),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,15 @@ where
     T: Deref<Target = [u8]>,
 {
     /// Creates a new `DoubleArray` with a byte slice.
-    /// Returns an error if the input is not a valid double-array trie.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// 1. `bytes.len()` is a non-zero multiple of `UNIT_SIZE`.
+    /// 2. The number of units (`bytes.len() / UNIT_SIZE`) is a multiple of `BLOCK_SIZE`.
+    /// 3. For every non-leaf unit at index `i`, `(unit.offset() as usize) ^ i` is
+    ///    strictly less than the total number of units.
     pub fn new(bytes: T) -> Result<Self> {
         Self::validate(&bytes)?;
         // SAFETY: `bytes` has just been checked to be a valid double array representation.
@@ -30,7 +38,12 @@ where
     ///
     /// # Safety
     ///
-    /// `bytes` must be a valid double array representation.
+    /// The caller must ensure all of the following:
+    ///
+    /// 1. `bytes.len()` is a non-zero multiple of `UNIT_SIZE`.
+    /// 2. The number of units (`bytes.len() / UNIT_SIZE`) is a multiple of `BLOCK_SIZE`.
+    /// 3. For every non-leaf unit at index `i`, `(unit.offset() as usize) ^ i` is
+    ///    strictly less than the total number of units.
     pub unsafe fn new_unchecked(bytes: T) -> Self {
         Self(bytes)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,12 +22,12 @@ where
     ///
     /// # Errors
     ///
-    /// Returns an error if:
+    /// Returns an error if any of the following holds:
     ///
-    /// 1. `bytes.len()` is a non-zero multiple of `UNIT_SIZE`.
-    /// 2. The number of units (`bytes.len() / UNIT_SIZE`) is a multiple of `BLOCK_SIZE`.
-    /// 3. For every non-leaf unit at index `i`, `(unit.offset() as usize) ^ i` is
-    ///    strictly less than the total number of units.
+    /// 1. `bytes.len()` is zero or not a multiple of `UNIT_SIZE`.
+    /// 2. The number of units is not a multiple of `BLOCK_SIZE`.
+    /// 3. For some non-leaf unit at index `i`, `(unit.offset() as usize) ^ i` is
+    ///    greater than or equal to the total number of units.
     pub fn new(bytes: T) -> Result<Self> {
         Self::validate(&bytes)?;
         // SAFETY: `bytes` has just been checked to be a valid double array representation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,43 @@ where
     T: Deref<Target = [u8]>,
 {
     /// Creates a new `DoubleArray` with a byte slice.
-    pub fn new(bytes: T) -> Self {
+    /// Returns `None` if the input is not a valid double-array trie.
+    pub fn new(bytes: T) -> Option<Self> {
+        if Self::validate(&bytes) {
+            // SAFETY: `bytes` has just been checked to be a valid double array representation.
+            Some(unsafe { Self::new_unchecked(bytes) })
+        } else {
+            None
+        }
+    }
+
+    /// Creates a new `DoubleArray` with a byte slice without verification.
+    ///
+    /// # Safety
+    ///
+    /// `bytes` must be a valid double array representation.
+    pub unsafe fn new_unchecked(bytes: T) -> Self {
         Self { 0: bytes }
+    }
+
+    /// Returns whether `bytes` is a valid double array representation.
+    fn validate(bytes: &[u8]) -> bool {
+        let (n_units, remainder) = (bytes.len() / UNIT_SIZE, bytes.len() % UNIT_SIZE);
+        if remainder != 0 || n_units == 0 {
+            return false;
+        }
+
+        bytes.chunks_exact(UNIT_SIZE).enumerate().all(|(i, chunk)| {
+            let val = u32::from_le_bytes(chunk.try_into().unwrap());
+            let unit = Unit::from_u32(val);
+            if unit.is_leaf() {
+                true
+            } else {
+                let base = unit.offset() ^ (i as u32);
+                let max_child_index = base as usize | 0xff;
+                max_child_index < n_units
+            }
+        })
     }
 
     /// Finds a value associated with a `key`.
@@ -163,7 +198,7 @@ mod tests {
         let da_bytes = DoubleArrayBuilder::build(keyset);
         assert!(da_bytes.is_some());
 
-        let da = DoubleArray::new(da_bytes.unwrap());
+        let da = DoubleArray::new(da_bytes.unwrap()).unwrap();
 
         for (key, value) in keyset {
             assert_eq!(da.exact_match_search(key), Some(*value as u32));
@@ -215,7 +250,7 @@ mod tests {
         let da_bytes = DoubleArrayBuilder::build(keyset);
         assert!(da_bytes.is_some());
 
-        let da = DoubleArray::new(da_bytes.unwrap());
+        let da = DoubleArray::new(da_bytes.unwrap()).unwrap();
 
         for (key, value) in keyset {
             assert_eq!(da.exact_match_search(key), Some(*value as u32));
@@ -243,7 +278,7 @@ mod tests {
         let da_bytes = DoubleArrayBuilder::build(keyset);
         assert!(da_bytes.is_some());
 
-        let da_orig = DoubleArray::new(da_bytes.unwrap());
+        let da_orig = DoubleArray::new(da_bytes.unwrap()).unwrap();
         let da = da_orig.clone();
 
         for (key, value) in keyset {
@@ -281,5 +316,11 @@ mod tests {
             da.common_prefix_search("d".as_bytes()).collect::<Vec<_>>(),
             vec![]
         );
+    }
+
+    #[test]
+    fn test_invalid_new() {
+        let da = DoubleArray::new(vec![1, 2, 3]);
+        assert!(da.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,14 @@ pub mod builder;
 pub mod errors;
 pub mod unit;
 
+use crate::builder::BLOCK_SIZE;
 use crate::errors::{Result, YadaError};
 use crate::unit::{Unit, UnitID, UNIT_SIZE};
 use std::convert::TryInto;
 use std::ops::Deref;
 
 /// A double array trie.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct DoubleArray<T>(pub T)
 where
     T: Deref<Target = [u8]>;
@@ -36,28 +37,33 @@ where
 
     /// Validates that `bytes` is a valid double array representation.
     fn validate(bytes: &[u8]) -> Result<()> {
-        let (n_units, remainder) = (bytes.len() / UNIT_SIZE, bytes.len() % UNIT_SIZE);
+        let (num_units, remainder) = (bytes.len() / UNIT_SIZE, bytes.len() % UNIT_SIZE);
         if remainder != 0 {
             return Err(YadaError::UnalignedDoubleArray {
                 len: bytes.len(),
                 unit_size: UNIT_SIZE,
             });
         }
-        if n_units == 0 {
+        if num_units == 0 {
             return Err(YadaError::EmptyDoubleArray);
+        }
+        if num_units % BLOCK_SIZE != 0 {
+            return Err(YadaError::UnalignedDoubleArrayBlocks {
+                num_units,
+                block_size: BLOCK_SIZE,
+            });
         }
 
         for (i, chunk) in bytes.chunks_exact(UNIT_SIZE).enumerate() {
             let val = u32::from_le_bytes(chunk.try_into().unwrap());
             let unit = Unit::from_u32(val);
             if !unit.is_leaf() {
-                let base = unit.offset() ^ (i as u32);
-                let max_child_index = base as usize | 0xff;
-                if max_child_index >= n_units {
+                let offset = (unit.offset() as usize) ^ (i as usize);
+                if offset >= num_units {
                     return Err(YadaError::InvalidDoubleArrayUnit {
                         index: i,
-                        child_index: max_child_index,
-                        num_units: n_units,
+                        offset,
+                        num_units,
                     });
                 }
             }
@@ -186,9 +192,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::builder::DoubleArrayBuilder;
+    use crate::builder::{DoubleArrayBuilder, BLOCK_SIZE};
     use crate::errors::YadaError;
-    use crate::unit::UNIT_SIZE;
+    use crate::unit::{Unit, UNIT_SIZE};
     use crate::DoubleArray;
 
     #[test]
@@ -332,38 +338,49 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_new() {
-        let da = DoubleArray::new(vec![1, 2, 3]);
-        let err = match da {
-            Ok(_) => panic!("expected an error"),
-            Err(err) => err,
-        };
+    fn test_new_rejects_unaligned_bytes() {
+        let err = DoubleArray::new(vec![1, 2, 3]).unwrap_err();
         assert_eq!(
             err,
             YadaError::UnalignedDoubleArray {
                 len: 3,
-                unit_size: UNIT_SIZE
+                unit_size: UNIT_SIZE,
             }
         );
+    }
 
-        let da = DoubleArray::new(Vec::new());
-        let err = match da {
-            Ok(_) => panic!("expected an error"),
-            Err(err) => err,
-        };
+    #[test]
+    fn test_new_rejects_empty_double_array() {
+        let err = DoubleArray::new(Vec::new()).unwrap_err();
         assert_eq!(err, YadaError::EmptyDoubleArray);
+    }
 
-        let da = DoubleArray::new(vec![0, 0, 0, 0]);
-        let err = match da {
-            Ok(_) => panic!("expected an error"),
-            Err(err) => err,
-        };
+    #[test]
+    fn test_new_rejects_unaligned_blocks() {
+        let err = DoubleArray::new(vec![0, 0, 0, 0]).unwrap_err();
+        assert_eq!(
+            err,
+            YadaError::UnalignedDoubleArrayBlocks {
+                num_units: 1,
+                block_size: BLOCK_SIZE,
+            }
+        );
+    }
+
+    #[test]
+    fn test_new_rejects_invalid_unit_offset() {
+        let mut da_bytes = vec![0; UNIT_SIZE * BLOCK_SIZE];
+        let mut unit = Unit::new();
+        unit.set_offset(BLOCK_SIZE as u32);
+        da_bytes[..UNIT_SIZE].copy_from_slice(&unit.as_u32().to_le_bytes());
+
+        let err = DoubleArray::new(da_bytes).unwrap_err();
         assert_eq!(
             err,
             YadaError::InvalidDoubleArrayUnit {
                 index: 0,
-                child_index: 255,
-                num_units: 1
+                offset: BLOCK_SIZE,
+                num_units: BLOCK_SIZE,
             }
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod builder;
 pub mod errors;
 pub mod unit;
 
+use crate::errors::{Result, YadaError};
 use crate::unit::{Unit, UnitID, UNIT_SIZE};
 use std::convert::TryInto;
 use std::ops::Deref;
@@ -17,14 +18,11 @@ where
     T: Deref<Target = [u8]>,
 {
     /// Creates a new `DoubleArray` with a byte slice.
-    /// Returns `None` if the input is not a valid double-array trie.
-    pub fn new(bytes: T) -> Option<Self> {
-        if Self::validate(&bytes) {
-            // SAFETY: `bytes` has just been checked to be a valid double array representation.
-            Some(unsafe { Self::new_unchecked(bytes) })
-        } else {
-            None
-        }
+    /// Returns an error if the input is not a valid double-array trie.
+    pub fn new(bytes: T) -> Result<Self> {
+        Self::validate(&bytes)?;
+        // SAFETY: `bytes` has just been checked to be a valid double array representation.
+        Ok(unsafe { Self::new_unchecked(bytes) })
     }
 
     /// Creates a new `DoubleArray` with a byte slice without verification.
@@ -36,24 +34,36 @@ where
         Self(bytes)
     }
 
-    /// Returns whether `bytes` is a valid double array representation.
-    fn validate(bytes: &[u8]) -> bool {
+    /// Validates that `bytes` is a valid double array representation.
+    fn validate(bytes: &[u8]) -> Result<()> {
         let (n_units, remainder) = (bytes.len() / UNIT_SIZE, bytes.len() % UNIT_SIZE);
-        if remainder != 0 || n_units == 0 {
-            return false;
+        if remainder != 0 {
+            return Err(YadaError::UnalignedDoubleArray {
+                len: bytes.len(),
+                unit_size: UNIT_SIZE,
+            });
+        }
+        if n_units == 0 {
+            return Err(YadaError::EmptyDoubleArray);
         }
 
-        bytes.chunks_exact(UNIT_SIZE).enumerate().all(|(i, chunk)| {
+        for (i, chunk) in bytes.chunks_exact(UNIT_SIZE).enumerate() {
             let val = u32::from_le_bytes(chunk.try_into().unwrap());
             let unit = Unit::from_u32(val);
-            if unit.is_leaf() {
-                true
-            } else {
+            if !unit.is_leaf() {
                 let base = unit.offset() ^ (i as u32);
                 let max_child_index = base as usize | 0xff;
-                max_child_index < n_units
+                if max_child_index >= n_units {
+                    return Err(YadaError::InvalidDoubleArrayUnit {
+                        index: i,
+                        child_index: max_child_index,
+                        num_units: n_units,
+                    });
+                }
             }
-        })
+        }
+
+        Ok(())
     }
 
     /// Finds a value associated with a `key`.
@@ -177,6 +187,8 @@ where
 #[cfg(test)]
 mod tests {
     use crate::builder::DoubleArrayBuilder;
+    use crate::errors::YadaError;
+    use crate::unit::UNIT_SIZE;
     use crate::DoubleArray;
 
     #[test]
@@ -322,6 +334,37 @@ mod tests {
     #[test]
     fn test_invalid_new() {
         let da = DoubleArray::new(vec![1, 2, 3]);
-        assert!(da.is_none());
+        let err = match da {
+            Ok(_) => panic!("expected an error"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err,
+            YadaError::UnalignedDoubleArray {
+                len: 3,
+                unit_size: UNIT_SIZE
+            }
+        );
+
+        let da = DoubleArray::new(Vec::new());
+        let err = match da {
+            Ok(_) => panic!("expected an error"),
+            Err(err) => err,
+        };
+        assert_eq!(err, YadaError::EmptyDoubleArray);
+
+        let da = DoubleArray::new(vec![0, 0, 0, 0]);
+        let err = match da {
+            Ok(_) => panic!("expected an error"),
+            Err(err) => err,
+        };
+        assert_eq!(
+            err,
+            YadaError::InvalidDoubleArrayUnit {
+                index: 0,
+                child_index: 255,
+                num_units: 1
+            }
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ where
     ///
     /// `bytes` must be a valid double array representation.
     pub unsafe fn new_unchecked(bytes: T) -> Self {
-        Self { 0: bytes }
+        Self(bytes)
     }
 
     /// Returns whether `bytes` is a valid double array representation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ where
             let val = u32::from_le_bytes(chunk.try_into().unwrap());
             let unit = Unit::from_u32(val);
             if !unit.is_leaf() {
-                let offset = (unit.offset() as usize) ^ (i as usize);
+                let offset = (unit.offset() as usize) ^ i;
                 if offset >= num_units {
                     return Err(YadaError::InvalidDoubleArrayUnit {
                         index: i,


### PR DESCRIPTION
This change adds a check that data passed to DoubleArray::new is a valid description of a DoubleArray. It also adds an unchecked unsafe version of DoubleArray::new for cases where performance is important and validity externally guaranteed.

This follows the proposal from https://github.com/takuyaa/yada/issues/24.

The change was done with the help of Gemini (AI), but understood and cross-checked by a human.