### PR TITLE
Apply Result-based error handling in DoubleArrayBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let keyset = &[
 ];
 
 // build a double-array trie binary
-let da_bytes: Option<Vec<u8>> = DoubleArrayBuilder::build(keyset);
+let da_bytes: Result<Vec<u8>, _> = DoubleArrayBuilder::build(keyset);
 ```
 
 ### Search entries by keys

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ See also [example code](examples/build_and_search.rs) for more details.
 
 ### Build a double-array trie
 
+`DoubleArrayBuilder::build` takes a sorted keyset of `(key, value)` pairs and
+returns the serialized double-array trie bytes.
+
 ```rust
 use yada::builder::DoubleArrayBuilder;
 
-// make a keyset which have key-value pairs
+// Make a sorted keyset of key-value pairs.
 let keyset = &[
     ("a".as_bytes(), 0),
     ("ab".as_bytes(), 1),
@@ -40,8 +43,8 @@ let keyset = &[
     ("c".as_bytes(), 5),
 ];
 
-// build a double-array trie binary
-let da_bytes: Result<Vec<u8>, _> = DoubleArrayBuilder::build(keyset);
+// Build a double-array trie binary.
+let da_bytes = DoubleArrayBuilder::build(keyset)?;
 ```
 
 ### Search entries by keys

--- a/README.md
+++ b/README.md
@@ -27,13 +27,10 @@ See also [example code](examples/build_and_search.rs) for more details.
 
 ### Build a double-array trie
 
-`DoubleArrayBuilder::build` takes a sorted keyset of `(key, value)` pairs and
-returns the serialized double-array trie bytes.
-
 ```rust
 use yada::builder::DoubleArrayBuilder;
 
-// Make a sorted keyset of key-value pairs.
+// make a keyset which have key-value pairs
 let keyset = &[
     ("a".as_bytes(), 0),
     ("ab".as_bytes(), 1),
@@ -43,7 +40,7 @@ let keyset = &[
     ("c".as_bytes(), 5),
 ];
 
-// Build a double-array trie binary.
+// build a double-array trie binary
 let da_bytes = DoubleArrayBuilder::build(keyset)?;
 ```
 

--- a/examples/build_and_search.rs
+++ b/examples/build_and_search.rs
@@ -16,7 +16,7 @@ fn main() {
 
     // build a double-array trie binary
     let da_bytes = DoubleArrayBuilder::build(keyset);
-    assert!(da_bytes.is_some());
+    assert!(da_bytes.is_ok());
 
     // create a double-array trie instance
     let da = DoubleArray::new(da_bytes.unwrap());

--- a/examples/load_from_file.rs
+++ b/examples/load_from_file.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // build a double-array trie binary
     let da_bytes = DoubleArrayBuilder::build(keyset);
-    assert!(da_bytes.is_some());
+    assert!(da_bytes.is_ok());
 
     // create a double-array trie instance
     let da = DoubleArray::new(da_bytes.unwrap());

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,10 +1,14 @@
+use crate::errors::{Result, YadaError};
 use crate::unit::{Unit, UnitID};
+use std::cmp::Ordering;
 use std::collections::HashSet;
 
 const BLOCK_SIZE: usize = 256;
 const NUM_TARGET_BLOCKS: i32 = 16; // the number of target blocks to find offsets
 const INVALID_NEXT: u8 = 0; // 0 means that there is no next unused unit
 const INVALID_PREV: u8 = 255; // 255 means that there is no previous unused unit
+const MAX_VALUE: u32 = (1 << 31) - 1;
+const MAX_NUM_UNITS: u32 = 1 << 29;
 
 /// A double-array trie builder.
 #[derive(Debug)]
@@ -22,23 +26,26 @@ impl DoubleArrayBuilder {
         }
     }
 
-    /// Builds a double-array trie with a `keyset` and returns it when build finished successfully.
-    /// Otherwise, returns `None`.
+    /// Builds a double-array trie with a `keyset`.
     /// The `keyset` must be sorted.
-    pub fn build<'a, T>(keyset: &[(T, u32)]) -> Option<Vec<u8>>
+    pub fn build<T>(keyset: &[(T, u32)]) -> Result<Vec<u8>>
     where
         T: AsRef<[u8]>,
     {
         Self::new().build_from_keyset(keyset)
     }
 
-    /// Builds a double-array trie with a `keyset` and returns it when build finished successfully.
-    /// Otherwise, returns `None`.
+    /// Builds a double-array trie with a `keyset`.
     /// The `keyset` must be sorted.
-    pub fn build_from_keyset<T>(&mut self, keyset: &[(T, u32)]) -> Option<Vec<u8>>
+    pub fn build_from_keyset<T>(&mut self, keyset: &[(T, u32)]) -> Result<Vec<u8>>
     where
         T: AsRef<[u8]>,
     {
+        self.validate_keyset(keyset)?;
+        if self.num_used_units() != 0 || !self.used_offsets.is_empty() {
+            return Err(YadaError::setup("builder must not be reused."));
+        }
+
         self.reserve(0); // reserve root node
         self.build_recursive(keyset, 0, 0, keyset.len(), 0)?;
 
@@ -50,7 +57,7 @@ impl DoubleArrayBuilder {
             }
         }
 
-        Some(da_bytes)
+        Ok(da_bytes)
     }
 
     /// Returns the number of `Unit`s that this builder contains.
@@ -108,6 +115,42 @@ impl DoubleArrayBuilder {
         block.reserve((unit_id % BLOCK_SIZE) as u8);
     }
 
+    fn validate_keyset<T>(&self, keyset: &[(T, u32)]) -> Result<()>
+    where
+        T: AsRef<[u8]>,
+    {
+        if keyset.is_empty() {
+            return Err(YadaError::input("keyset must not be empty."));
+        }
+
+        for (key, value) in keyset {
+            let key = key.as_ref();
+            if key.is_empty() {
+                return Err(YadaError::input("keyset must not contain an empty key."));
+            }
+            if key.contains(&0) {
+                return Err(YadaError::input("keys must not contain NULL."));
+            }
+            if *value > MAX_VALUE {
+                return Err(YadaError::scale("input value", MAX_VALUE));
+            }
+        }
+
+        for pair in keyset.windows(2) {
+            match pair[0].0.as_ref().cmp(pair[1].0.as_ref()) {
+                Ordering::Less => {}
+                Ordering::Equal => {
+                    return Err(YadaError::input("keyset must not contain duplicated keys."))
+                }
+                Ordering::Greater => {
+                    return Err(YadaError::input("keyset must be sorted."));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn build_recursive<T>(
         &mut self,
         keyset: &[(T, u32)],
@@ -115,7 +158,7 @@ impl DoubleArrayBuilder {
         begin: usize,
         end: usize,
         unit_id: UnitID,
-    ) -> Option<()>
+    ) -> Result<()>
     where
         T: AsRef<[u8]>,
     {
@@ -124,17 +167,21 @@ impl DoubleArrayBuilder {
         let mut value = None;
 
         for i in begin..end {
+            // This unwrap is safe because the loop condition ensures `i` is within `begin..end`.
             let key_value = keyset.get(i).unwrap();
             let label = {
                 let key = key_value.0.as_ref();
                 if depth == key.len() {
                     0
                 } else {
-                    *key.get(depth)?
+                    // This unwrap is safe because the loop condition ensures `depth` is within `0..key.len()`.
+                    *key.get(depth).unwrap()
                 }
             };
             if label == 0 {
-                assert!(value.is_none()); // there is just one '\0' in a key
+                // This should be safe because validate_keyset() ensures
+                // there is no duplicate keys.
+                assert!(value.is_none(), "there is just one '\0' in a key");
                 value = Some(key_value.1);
             }
             match labels.last_mut() {
@@ -149,26 +196,24 @@ impl DoubleArrayBuilder {
                 }
             }
         }
-        assert!(labels.len() > 0);
 
+        // This should be safe because the recursive call
+        // to build_recursive() will not be made if labels is empty.
         let last_label = labels.last_mut().unwrap();
         last_label.2 = end;
 
         let labels_ = labels.iter().map(|(key, _, _)| *key).collect::<Vec<_>>();
-        assert!(labels_.len() > 0);
 
         // search an offset where these children fits to unused positions.
         let offset: u32 = loop {
-            let offset = self.find_offset(unit_id, &labels_);
-            if offset.is_some() {
-                break offset.unwrap();
+            if let Some(offset) = self.find_offset(unit_id, &labels_) {
+                break offset;
+            }
+            if self.num_units() >= MAX_NUM_UNITS {
+                return Err(YadaError::scale("num_units", MAX_NUM_UNITS));
             }
             self.extend_block();
         };
-        assert!(
-            offset < (1u32 << 29),
-            "offset must be represented as 29 bits integer"
-        );
 
         // mark the offset used
         self.used_offsets.insert(offset);
@@ -177,12 +222,18 @@ impl DoubleArrayBuilder {
 
         // populate offset and has_leaf flag to parent node
         let parent_unit = self.get_unit_mut(unit_id);
+
+        // This should be safe because build_recursive() logically ensures
+        // that unit_id is an initialized unit before this point.
         assert_eq!(
             parent_unit.offset(),
             0,
             "offset() should return 0 before set_offset()"
         );
         parent_unit.set_offset(offset ^ unit_id as u32); // store the relative offset to the index
+
+        // This should be safe because build_recursive() logically ensures
+        // that unit_id is an initialized unit before this point.
         assert!(
             !parent_unit.has_leaf(),
             "has_leaf() should return false before set_has_leaf()"
@@ -196,14 +247,15 @@ impl DoubleArrayBuilder {
 
             let unit = self.get_unit_mut(child_id);
 
-            // child node units should be empty
+            // This should be safe because find_offset() ensures that
+            // child node units are empty.
             assert_eq!(unit.offset(), 0);
             assert_eq!(unit.label(), 0);
             assert_eq!(unit.value(), 0);
             assert!(!unit.has_leaf());
 
             if label == 0 {
-                assert!(value.is_some());
+                // This should be safe logically.
                 unit.set_value(value.unwrap());
             } else {
                 unit.set_label(label);
@@ -212,16 +264,19 @@ impl DoubleArrayBuilder {
 
         // recursive call in depth-first order
         for (label, begin, end) in labels {
+            if label == 0 {
+                continue;
+            }
             self.build_recursive(
                 keyset,
                 depth + 1,
                 begin,
                 end,
                 (label as u32 ^ offset) as UnitID,
-            );
+            )?;
         }
 
-        Some(())
+        Ok(())
     }
 
     fn find_offset(&self, unit_id: UnitID, labels: &Vec<u8>) -> Option<u32> {
@@ -448,6 +503,7 @@ impl std::fmt::Debug for DoubleArrayBlock {
 #[cfg(test)]
 mod tests {
     use crate::builder::DoubleArrayBuilder;
+    use crate::errors::YadaError;
 
     #[test]
     fn test_build() {
@@ -466,10 +522,48 @@ mod tests {
 
         let mut builder = DoubleArrayBuilder::new();
         let da = builder.build_from_keyset(keyset);
-        assert!(da.is_some());
+        assert!(da.is_ok());
 
         assert!(0 < builder.num_units());
         assert!(0 < builder.num_used_units());
         assert!(builder.num_used_units() < builder.num_units());
+    }
+
+    #[test]
+    fn test_invalid_keyset() {
+        assert!(matches!(
+            DoubleArrayBuilder::build::<&[u8]>(&[]),
+            Err(YadaError::Input(_))
+        ));
+        assert!(matches!(
+            DoubleArrayBuilder::build(&[("".as_bytes(), 0)]),
+            Err(YadaError::Input(_))
+        ));
+        assert!(matches!(
+            DoubleArrayBuilder::build(&[("a\0b".as_bytes(), 0)]),
+            Err(YadaError::Input(_))
+        ));
+        assert!(matches!(
+            DoubleArrayBuilder::build(&[("b".as_bytes(), 0), ("a".as_bytes(), 1)]),
+            Err(YadaError::Input(_))
+        ));
+        assert!(matches!(
+            DoubleArrayBuilder::build(&[("a".as_bytes(), 0), ("a".as_bytes(), 1)]),
+            Err(YadaError::Input(_))
+        ));
+        assert!(matches!(
+            DoubleArrayBuilder::build(&[("a".as_bytes(), 1 << 31)]),
+            Err(YadaError::Scale(_))
+        ));
+    }
+
+    #[test]
+    fn test_builder_must_not_be_reused() {
+        let mut builder = DoubleArrayBuilder::new();
+        assert!(builder.build_from_keyset(&[("a".as_bytes(), 0)]).is_ok());
+        assert!(matches!(
+            builder.build_from_keyset(&[("b".as_bytes(), 1)]),
+            Err(YadaError::Setup(_))
+        ));
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -109,30 +109,28 @@ impl DoubleArrayBuilder {
         T: AsRef<[u8]>,
     {
         if keyset.is_empty() {
-            return Err(YadaError::input("keyset must not be empty."));
+            return Err(YadaError::EmptyKeyset);
         }
 
         for (key, value) in keyset {
             let key = key.as_ref();
             if key.is_empty() {
-                return Err(YadaError::input("keyset must not contain an empty key."));
+                return Err(YadaError::EmptyKey);
             }
             if key.contains(&0) {
-                return Err(YadaError::input("keys must not contain NULL."));
+                return Err(YadaError::NullByte);
             }
             if *value > MAX_VALUE {
-                return Err(YadaError::scale("input value", MAX_VALUE));
+                return Err(YadaError::ValueTooLarge { max: MAX_VALUE });
             }
         }
 
         for pair in keyset.windows(2) {
             match pair[0].0.as_ref().cmp(pair[1].0.as_ref()) {
                 Ordering::Less => {}
-                Ordering::Equal => {
-                    return Err(YadaError::input("keyset must not contain duplicated keys."))
-                }
+                Ordering::Equal => return Err(YadaError::DuplicateKey),
                 Ordering::Greater => {
-                    return Err(YadaError::input("keyset must be sorted."));
+                    return Err(YadaError::UnsortedKeyset);
                 }
             }
         }
@@ -199,7 +197,7 @@ impl DoubleArrayBuilder {
                 break offset;
             }
             if self.num_units() >= MAX_NUM_UNITS {
-                return Err(YadaError::scale("num_units", MAX_NUM_UNITS));
+                return Err(YadaError::TooManyUnits { max: MAX_NUM_UNITS });
             }
             self.extend_block();
         };
@@ -517,27 +515,27 @@ mod tests {
     fn test_invalid_keyset() {
         assert!(matches!(
             DoubleArrayBuilder::build::<&[u8]>(&[]),
-            Err(YadaError::Input(_))
+            Err(YadaError::EmptyKeyset)
         ));
         assert!(matches!(
             DoubleArrayBuilder::build(&[("".as_bytes(), 0)]),
-            Err(YadaError::Input(_))
+            Err(YadaError::EmptyKey)
         ));
         assert!(matches!(
             DoubleArrayBuilder::build(&[("a\0b".as_bytes(), 0)]),
-            Err(YadaError::Input(_))
+            Err(YadaError::NullByte)
         ));
         assert!(matches!(
             DoubleArrayBuilder::build(&[("b".as_bytes(), 0), ("a".as_bytes(), 1)]),
-            Err(YadaError::Input(_))
+            Err(YadaError::UnsortedKeyset)
         ));
         assert!(matches!(
             DoubleArrayBuilder::build(&[("a".as_bytes(), 0), ("a".as_bytes(), 1)]),
-            Err(YadaError::Input(_))
+            Err(YadaError::DuplicateKey)
         ));
         assert!(matches!(
             DoubleArrayBuilder::build(&[("a".as_bytes(), 1 << 31)]),
-            Err(YadaError::Scale(_))
+            Err(YadaError::ValueTooLarge { max }) if max == super::MAX_VALUE
         ));
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -32,25 +32,14 @@ impl DoubleArrayBuilder {
     where
         T: AsRef<[u8]>,
     {
-        Self::new().build_from_keyset(keyset)
-    }
+        let mut builder = Self::new();
+        builder.validate_keyset(keyset)?;
 
-    /// Builds a double-array trie with a `keyset`.
-    /// The `keyset` must be sorted.
-    pub fn build_from_keyset<T>(&mut self, keyset: &[(T, u32)]) -> Result<Vec<u8>>
-    where
-        T: AsRef<[u8]>,
-    {
-        self.validate_keyset(keyset)?;
-        if self.num_used_units() != 0 || !self.used_offsets.is_empty() {
-            return Err(YadaError::setup("builder must not be reused."));
-        }
+        builder.reserve(0); // reserve root node
+        builder.build_recursive(keyset, 0, 0, keyset.len(), 0)?;
 
-        self.reserve(0); // reserve root node
-        self.build_recursive(keyset, 0, 0, keyset.len(), 0)?;
-
-        let mut da_bytes = Vec::with_capacity(self.blocks.len() * BLOCK_SIZE);
-        for block in &self.blocks {
+        let mut da_bytes = Vec::with_capacity(builder.blocks.len() * BLOCK_SIZE);
+        for block in &builder.blocks {
             for unit in block.units.iter() {
                 let bytes = unit.as_u32().to_le_bytes();
                 da_bytes.extend_from_slice(&bytes);
@@ -520,13 +509,8 @@ mod tests {
             ("abcdef".as_bytes(), 0),
         ];
 
-        let mut builder = DoubleArrayBuilder::new();
-        let da = builder.build_from_keyset(keyset);
+        let da = DoubleArrayBuilder::build(keyset);
         assert!(da.is_ok());
-
-        assert!(0 < builder.num_units());
-        assert!(0 < builder.num_used_units());
-        assert!(builder.num_used_units() < builder.num_units());
     }
 
     #[test]
@@ -554,16 +538,6 @@ mod tests {
         assert!(matches!(
             DoubleArrayBuilder::build(&[("a".as_bytes(), 1 << 31)]),
             Err(YadaError::Scale(_))
-        ));
-    }
-
-    #[test]
-    fn test_builder_must_not_be_reused() {
-        let mut builder = DoubleArrayBuilder::new();
-        assert!(builder.build_from_keyset(&[("a".as_bytes(), 0)]).is_ok());
-        assert!(matches!(
-            builder.build_from_keyset(&[("b".as_bytes(), 1)]),
-            Err(YadaError::Setup(_))
         ));
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -7,8 +7,8 @@ const BLOCK_SIZE: usize = 256;
 const NUM_TARGET_BLOCKS: i32 = 16; // the number of target blocks to find offsets
 const INVALID_NEXT: u8 = 0; // 0 means that there is no next unused unit
 const INVALID_PREV: u8 = 255; // 255 means that there is no previous unused unit
-const MAX_VALUE: u32 = (1 << 31) - 1;
-const MAX_NUM_UNITS: u32 = 1 << 29;
+const MAX_VALUE: u32 = (1 << 31) - 1; // the maximum value that can be stored in a unit
+const MAX_NUM_UNITS: u32 = 1 << 29; // the maximum number of units that can be stored
 
 /// A double-array trie builder.
 #[derive(Debug)]
@@ -154,14 +154,16 @@ impl DoubleArrayBuilder {
         let mut value = None;
 
         for i in begin..end {
-            // This unwrap is safe because the loop condition ensures `i` is within `begin..end`.
+            // This unwrap is safe because the recursive call
+            // ensures `i` is within `begin..end`.
             let key_value = keyset.get(i).unwrap();
             let label = {
                 let key = key_value.0.as_ref();
                 if depth == key.len() {
                     0
                 } else {
-                    // This unwrap is safe because the loop condition ensures `depth` is within `0..key.len()`.
+                    // This unwrap is safe because the recursive call
+                    // ensures `depth` is within `0..key.len()`.
                     *key.get(depth).unwrap()
                 }
             };
@@ -184,8 +186,8 @@ impl DoubleArrayBuilder {
             }
         }
 
-        // This should be safe because the recursive call
-        // to build_recursive() will not be made if labels is empty.
+        // This unwrap is safe because the recursive call
+        // ensures begin..end is not empty.
         let last_label = labels.last_mut().unwrap();
         last_label.2 = end;
 
@@ -210,7 +212,7 @@ impl DoubleArrayBuilder {
         // populate offset and has_leaf flag to parent node
         let parent_unit = self.get_unit_mut(unit_id);
 
-        // This should be safe because build_recursive() logically ensures
+        // This should be safe because the recursive call ensures
         // that unit_id is an initialized unit before this point.
         assert_eq!(
             parent_unit.offset(),
@@ -219,7 +221,7 @@ impl DoubleArrayBuilder {
         );
         parent_unit.set_offset(offset ^ unit_id as u32); // store the relative offset to the index
 
-        // This should be safe because build_recursive() logically ensures
+        // This should be safe because the recursive call ensures
         // that unit_id is an initialized unit before this point.
         assert!(
             !parent_unit.has_leaf(),
@@ -234,15 +236,14 @@ impl DoubleArrayBuilder {
 
             let unit = self.get_unit_mut(child_id);
 
-            // This should be safe because find_offset() ensures that
-            // child node units are empty.
+            // These should be safe because find_offset() ensures
+            // that child node units are empty.
             assert_eq!(unit.offset(), 0);
             assert_eq!(unit.label(), 0);
             assert_eq!(unit.value(), 0);
             assert!(!unit.has_leaf());
 
             if label == 0 {
-                // This should be safe logically.
                 unit.set_value(value.unwrap());
             } else {
                 unit.set_label(label);
@@ -251,6 +252,7 @@ impl DoubleArrayBuilder {
 
         // recursive call in depth-first order
         for (label, begin, end) in labels {
+            // skip leaf node because it has no children
             if label == 0 {
                 continue;
             }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -181,7 +181,7 @@ impl DoubleArrayBuilder {
             if label == 0 {
                 // This should be safe because validate_keyset() ensures
                 // there is no duplicate keys.
-                assert!(value.is_none(), "there is just one '\0' in a key");
+                assert!(value.is_none(), r"there is just one '\0' in a key");
                 value = Some(key_value.1);
             }
             match labels.last_mut() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -43,9 +43,9 @@ impl DoubleArrayBuilder {
     where
         T: AsRef<[u8]>,
     {
-        let mut builder = Self::new();
         Self::validate_keyset(keyset)?;
 
+        let mut builder = Self::new();
         builder.reserve(0); // reserve root node
         builder.build_recursive(keyset, 0, 0, keyset.len(), 0)?;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -44,7 +44,7 @@ impl DoubleArrayBuilder {
         T: AsRef<[u8]>,
     {
         let mut builder = Self::new();
-        builder.validate_keyset(keyset)?;
+        Self::validate_keyset(keyset)?;
 
         builder.reserve(0); // reserve root node
         builder.build_recursive(keyset, 0, 0, keyset.len(), 0)?;
@@ -115,7 +115,7 @@ impl DoubleArrayBuilder {
         block.reserve((unit_id % BLOCK_SIZE) as u8);
     }
 
-    fn validate_keyset<T>(&self, keyset: &[(T, u32)]) -> Result<()>
+    fn validate_keyset<T>(keyset: &[(T, u32)]) -> Result<()>
     where
         T: AsRef<[u8]>,
     {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -26,8 +26,19 @@ impl DoubleArrayBuilder {
         }
     }
 
-    /// Builds a double-array trie with a `keyset`.
-    /// The `keyset` must be sorted.
+    /// Builds a serialized double-array trie from a `keyset`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    ///
+    /// - the keyset is empty
+    /// - the keyset contains an empty key
+    /// - a key contains a NUL byte (`0x00`)
+    /// - the keyset contains duplicate keys
+    /// - the keyset is not sorted in bytewise lexicographic order
+    /// - a value is greater than `2^31 - 1`
+    /// - the resulting trie would contain more than `2^29` units
     pub fn build<T>(keyset: &[(T, u32)]) -> Result<Vec<u8>>
     where
         T: AsRef<[u8]>,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -525,30 +525,52 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_keyset() {
-        assert!(matches!(
-            DoubleArrayBuilder::build::<&[u8]>(&[]),
-            Err(YadaError::EmptyKeyset)
-        ));
-        assert!(matches!(
-            DoubleArrayBuilder::build(&[("".as_bytes(), 0)]),
-            Err(YadaError::EmptyKey)
-        ));
-        assert!(matches!(
-            DoubleArrayBuilder::build(&[("a\0b".as_bytes(), 0)]),
-            Err(YadaError::NullByte)
-        ));
-        assert!(matches!(
-            DoubleArrayBuilder::build(&[("b".as_bytes(), 0), ("a".as_bytes(), 1)]),
-            Err(YadaError::UnsortedKeyset)
-        ));
-        assert!(matches!(
-            DoubleArrayBuilder::build(&[("a".as_bytes(), 0), ("a".as_bytes(), 1)]),
-            Err(YadaError::DuplicateKey)
-        ));
-        assert!(matches!(
-            DoubleArrayBuilder::build(&[("a".as_bytes(), 1 << 31)]),
-            Err(YadaError::ValueTooLarge { max }) if max == super::MAX_VALUE
-        ));
+    fn test_empty_keyset() {
+        assert_eq!(
+            DoubleArrayBuilder::build::<&[u8]>(&[]).unwrap_err(),
+            YadaError::EmptyKeyset
+        );
+    }
+
+    #[test]
+    fn test_empty_key() {
+        assert_eq!(
+            DoubleArrayBuilder::build(&[("".as_bytes(), 0)]).unwrap_err(),
+            YadaError::EmptyKey
+        );
+    }
+
+    #[test]
+    fn test_null_byte_in_key() {
+        assert_eq!(
+            DoubleArrayBuilder::build(&[("a\0b".as_bytes(), 0)]).unwrap_err(),
+            YadaError::NullByte
+        );
+    }
+
+    #[test]
+    fn test_unsorted_keyset() {
+        assert_eq!(
+            DoubleArrayBuilder::build(&[("b".as_bytes(), 0), ("a".as_bytes(), 1)]).unwrap_err(),
+            YadaError::UnsortedKeyset
+        );
+    }
+
+    #[test]
+    fn test_duplicate_key() {
+        assert_eq!(
+            DoubleArrayBuilder::build(&[("a".as_bytes(), 0), ("a".as_bytes(), 1)]).unwrap_err(),
+            YadaError::DuplicateKey
+        );
+    }
+
+    #[test]
+    fn test_too_large_value() {
+        assert_eq!(
+            DoubleArrayBuilder::build(&[("a".as_bytes(), 1 << 31)]).unwrap_err(),
+            YadaError::ValueTooLarge {
+                max: super::MAX_VALUE
+            }
+        );
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,61 +5,46 @@ use std::{fmt, result};
 pub type Result<T, E = YadaError> = result::Result<T, E>;
 
 /// Errors in Yada.
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum YadaError {
-    /// Contains [`InputError`].
-    Input(InputError),
+    /// The keyset is empty.
+    EmptyKeyset,
 
-    /// Contains [`ScaleError`].
-    Scale(ScaleError),
+    /// The keyset contains an empty key.
+    EmptyKey,
+
+    /// A key contains a null byte.
+    NullByte,
+
+    /// The keyset contains duplicated keys.
+    DuplicateKey,
+
+    /// The keyset is not sorted.
+    UnsortedKeyset,
+
+    /// An input value exceeds the maximum value.
+    ValueTooLarge { max: u32 },
+
+    /// The resulting trie exceeds the maximum number of units.
+    TooManyUnits { max: u32 },
 }
 
 impl fmt::Display for YadaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Input(e) => e.fmt(f),
-            Self::Scale(e) => e.fmt(f),
+            Self::EmptyKeyset => write!(f, "keyset must not be empty"),
+            Self::EmptyKey => write!(f, "keyset must not contain an empty key"),
+            Self::NullByte => write!(f, "keys must not contain NULL"),
+            Self::DuplicateKey => write!(f, "keyset must not contain duplicated keys"),
+            Self::UnsortedKeyset => write!(f, "keyset must be sorted"),
+            Self::ValueTooLarge { max } => {
+                write!(f, "input value must be no greater than {max}")
+            }
+            Self::TooManyUnits { max } => {
+                write!(f, "num_units must be no greater than {max}")
+            }
         }
     }
 }
 
 impl std::error::Error for YadaError {}
-
-impl YadaError {
-    pub(crate) const fn input(msg: &'static str) -> Self {
-        Self::Input(InputError { msg })
-    }
-
-    pub(crate) const fn scale(arg: &'static str, max: u32) -> Self {
-        Self::Scale(ScaleError { arg, max })
-    }
-}
-
-/// Error used when the input argument is invalid.
-#[derive(Debug)]
-pub struct InputError {
-    msg: &'static str,
-}
-
-impl fmt::Display for InputError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "InputError: {}", self.msg)
-    }
-}
-
-/// Error used when the scale of a resulting trie exceeds the expected one.
-#[derive(Debug)]
-pub struct ScaleError {
-    arg: &'static str,
-    max: u32,
-}
-
-impl fmt::Display for ScaleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "ScaleError: {} must be no greater than {}",
-            self.arg, self.max
-        )
-    }
-}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,9 +10,6 @@ pub enum YadaError {
     /// Contains [`InputError`].
     Input(InputError),
 
-    /// Contains [`SetupError`].
-    Setup(SetupError),
-
     /// Contains [`ScaleError`].
     Scale(ScaleError),
 }
@@ -21,7 +18,6 @@ impl fmt::Display for YadaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Input(e) => e.fmt(f),
-            Self::Setup(e) => e.fmt(f),
             Self::Scale(e) => e.fmt(f),
         }
     }
@@ -48,18 +44,6 @@ pub struct InputError {
 impl fmt::Display for InputError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "InputError: {}", self.msg)
-    }
-}
-
-/// Error used when the setup is invalid.
-#[derive(Debug)]
-pub struct SetupError {
-    msg: &'static str,
-}
-
-impl fmt::Display for SetupError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "SetupError: {}", self.msg)
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,10 +34,6 @@ impl YadaError {
         Self::Input(InputError { msg })
     }
 
-    pub(crate) const fn setup(msg: &'static str) -> Self {
-        Self::Setup(SetupError { msg })
-    }
-
     pub(crate) const fn scale(arg: &'static str, max: u32) -> Self {
         Self::Scale(ScaleError { arg, max })
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,85 @@
+//! Definition of errors.
+use std::{fmt, result};
+
+/// A specialized `Result` type for Yada.
+pub type Result<T, E = YadaError> = result::Result<T, E>;
+
+/// Errors in Yada.
+#[derive(Debug)]
+pub enum YadaError {
+    /// Contains [`InputError`].
+    Input(InputError),
+
+    /// Contains [`SetupError`].
+    Setup(SetupError),
+
+    /// Contains [`ScaleError`].
+    Scale(ScaleError),
+}
+
+impl fmt::Display for YadaError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Input(e) => e.fmt(f),
+            Self::Setup(e) => e.fmt(f),
+            Self::Scale(e) => e.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for YadaError {}
+
+impl YadaError {
+    pub(crate) const fn input(msg: &'static str) -> Self {
+        Self::Input(InputError { msg })
+    }
+
+    pub(crate) const fn setup(msg: &'static str) -> Self {
+        Self::Setup(SetupError { msg })
+    }
+
+    pub(crate) const fn scale(arg: &'static str, max: u32) -> Self {
+        Self::Scale(ScaleError { arg, max })
+    }
+}
+
+/// Error used when the input argument is invalid.
+#[derive(Debug)]
+pub struct InputError {
+    msg: &'static str,
+}
+
+impl fmt::Display for InputError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "InputError: {}", self.msg)
+    }
+}
+
+/// Error used when the setup is invalid.
+#[derive(Debug)]
+pub struct SetupError {
+    msg: &'static str,
+}
+
+impl fmt::Display for SetupError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SetupError: {}", self.msg)
+    }
+}
+
+/// Error used when the scale of a resulting trie exceeds the expected one.
+#[derive(Debug)]
+pub struct ScaleError {
+    arg: &'static str,
+    max: u32,
+}
+
+impl fmt::Display for ScaleError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "ScaleError: {} must be no greater than {}",
+            self.arg, self.max
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod builder;
+pub mod errors;
 pub mod unit;
 
 use crate::unit::{Unit, UnitID, UNIT_SIZE};
@@ -161,7 +162,7 @@ mod tests {
         ];
 
         let da_bytes = DoubleArrayBuilder::build(keyset);
-        assert!(da_bytes.is_some());
+        assert!(da_bytes.is_ok());
 
         let da = DoubleArray::new(da_bytes.unwrap());
 
@@ -213,7 +214,7 @@ mod tests {
         ];
 
         let da_bytes = DoubleArrayBuilder::build(keyset);
-        assert!(da_bytes.is_some());
+        assert!(da_bytes.is_ok());
 
         let da = DoubleArray::new(da_bytes.unwrap());
 
@@ -241,7 +242,7 @@ mod tests {
         ];
 
         let da_bytes = DoubleArrayBuilder::build(keyset);
-        assert!(da_bytes.is_some());
+        assert!(da_bytes.is_ok());
 
         let da_orig = DoubleArray::new(da_bytes.unwrap());
         let da = da_orig.clone();


### PR DESCRIPTION
## Summary

This PR changes `DoubleArrayBuilder` to use `Result`-based error handling and return build failures as `YadaError`. This allows callers to distinguish invalid keysets and trie size limit violations.

It also removes the stateful `build_from_keyset` API, which was not intended to be reused, and makes `DoubleArrayBuilder::build` create and use a builder internally for a single build.

This PR includes **breaking changes**, but I believe they are necessary to make build failures explicit and prevent misuse of the builder API.

## Changes

- Add `YadaError` and `yada::errors::Result`
- Change `DoubleArrayBuilder::build` from `Option<Vec<u8>>` to `Result<Vec<u8>, YadaError>`
- Remove `build_from_keyset`
- Add keyset validation for:
  - empty keysets
  - empty keys
  - keys containing NUL bytes
  - duplicate keys
  - unsorted keysets
  - values greater than `2^31 - 1`
- Return `TooManyUnits` when the number of units exceeds `2^29`
- Propagate errors from `build_recursive`
- Skip unnecessary recursion into leaf nodes
- Update README, examples, and tests

## Compatibility

This PR includes breaking changes:

- `DoubleArrayBuilder::build` now returns `Result`
- `build_from_keyset` has been removed; users should migrate to `DoubleArrayBuilder::build`

## Tests

- `cargo test`
