### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.65.0
+      - uses: dtolnay/rust-toolchain@1.58.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check -p yada

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,26 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --workspace --all-features
+      - run: cargo test --workspace
 
   fmt:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -31,10 +37,31 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-features -- -D warnings
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  doc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc -p yada --no-deps
+
+  msrv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.65.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check -p yada

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -52,7 +52,7 @@ jobs:
     env:
       RUSTDOCFLAGS: -D warnings
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc -p yada --no-deps
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.58.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check -p yada

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace --all-features
+
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["double-array", "trie", "search"]
 categories = ["algorithms", "compression", "data-structures", "text-processing"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
-rust-version = "1.65.0"
+rust-version = "1.58.0"
 
 [workspace]
 members = ["bench"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["double-array", "trie", "search"]
 categories = ["algorithms", "compression", "data-structures", "text-processing"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+rust-version = "1.65.0"
 
 [workspace]
 members = ["bench"]

--- a/bench/src/bin/convert.rs
+++ b/bench/src/bin/convert.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Error> {
 
     for line in io::stdin().lock().lines() {
         let line = line?;
-        lexicon.push(line.split(',').nth(0).unwrap().to_string());
+        lexicon.push(line.split(',').next().unwrap().to_string());
     }
 
     // unique keys

--- a/examples/build_and_search.rs
+++ b/examples/build_and_search.rs
@@ -23,7 +23,7 @@ fn main() {
 
     // exact match search
     for (key, value) in keyset {
-        assert_eq!(da.exact_match_search(key), Some(*value as u32));
+        assert_eq!(da.exact_match_search(key), Some(*value));
     }
     assert_eq!(da.exact_match_search("aa".as_bytes()), None);
     assert_eq!(da.exact_match_search("aba".as_bytes()), None);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,6 +17,12 @@ pub struct DoubleArrayBuilder {
     pub used_offsets: HashSet<u32>,
 }
 
+impl Default for DoubleArrayBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DoubleArrayBuilder {
     /// Constructs a new `DoubleArrayBuilder` with an empty `DoubleArrayBlock`.
     pub fn new() -> Self {
@@ -346,7 +352,7 @@ impl DoubleArrayBlock {
         unit_id: UnitID,
         labels: &'a Vec<u8>,
     ) -> impl Iterator<Item = u8> + 'a {
-        assert!(labels.len() > 0);
+        assert!(!labels.is_empty());
         FindOffset {
             unused_id: self.head_unused,
             block: self,
@@ -401,11 +407,7 @@ impl<'a> FindOffset<'a> {
             let id = offset ^ label;
             match self.block.is_used.get(id as UnitID) {
                 Some(is_used) => !*is_used,
-                None => {
-                    // something is going wrong
-                    assert!(false, "DoubleArrayBlock is_used.get({}) was fault", id);
-                    false
-                }
+                None => panic!("DoubleArrayBlock is_used.get({}) was fault", id),
             }
         })
     }
@@ -415,12 +417,12 @@ impl<'a> Iterator for FindOffset<'a> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.unused_id == INVALID_NEXT && self.block.is_used[self.unused_id as usize] == true {
+        if self.unused_id == INVALID_NEXT && self.block.is_used[self.unused_id as usize] {
             return None;
         }
 
         // return if this block is full
-        if self.block.head_unused == INVALID_NEXT && self.block.is_used[0] == true {
+        if self.block.head_unused == INVALID_NEXT && self.block.is_used[0] {
             assert!(self.block.is_used.iter().all(|is_used| *is_used)); // assert full
             return None;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,7 +167,7 @@ mod tests {
         let da = DoubleArray::new(da_bytes.unwrap());
 
         for (key, value) in keyset {
-            assert_eq!(da.exact_match_search(key), Some(*value as u32));
+            assert_eq!(da.exact_match_search(key), Some(*value));
         }
         assert_eq!(da.exact_match_search("aa".as_bytes()), None);
         assert_eq!(da.exact_match_search("abc".as_bytes()), None);
@@ -219,7 +219,7 @@ mod tests {
         let da = DoubleArray::new(da_bytes.unwrap());
 
         for (key, value) in keyset {
-            assert_eq!(da.exact_match_search(key), Some(*value as u32));
+            assert_eq!(da.exact_match_search(key), Some(*value));
         }
         assert_eq!(da.exact_match_search("dasss"), None);
     }
@@ -248,7 +248,7 @@ mod tests {
         let da = da_orig.clone();
 
         for (key, value) in keyset {
-            assert_eq!(da.exact_match_search(key), Some(*value as u32));
+            assert_eq!(da.exact_match_search(key), Some(*value));
         }
         assert_eq!(da.exact_match_search("aa".as_bytes()), None);
         assert_eq!(da.exact_match_search("abc".as_bytes()), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ where
 {
     /// Creates a new `DoubleArray` with a byte slice.
     pub fn new(bytes: T) -> Self {
-        Self { 0: bytes }
+        Self(bytes)
     }
 
     /// Finds a value associated with a `key`.
@@ -52,7 +52,7 @@ where
         }
 
         // traverse node by NULL ('\0')
-        let node_pos = (unit.offset() ^ node_pos as u32 ^ 0u32) as UnitID;
+        let node_pos = (unit.offset() ^ node_pos as u32) as UnitID;
         unit = self.get_unit(node_pos)?;
         assert!(unit.is_leaf());
         assert!(unit.value() < (1 << 31));

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -5,9 +5,7 @@ pub type UnitID = usize;
 pub const UNIT_SIZE: usize = std::mem::size_of::<u32>();
 
 /// An unit represents an element in a double-array.
-#[derive(Copy, Clone)]
-pub struct Unit(u32);
-
+///
 /// Unit represents one node of a double array trie. The bit width of each node is 32-bits.
 ///
 /// The bit layout of a non-leaf node:
@@ -36,6 +34,9 @@ pub struct Unit(u32);
 ///   VALUE                31-bits value that represents a value of the double array node.
 ///   IS_LEAF (I)          1-bit flag that indicates whether the node is a leaf node or not.
 ///                        This flag is always 1 in this case.
+#[derive(Copy, Clone)]
+pub struct Unit(u32);
+
 impl Default for Unit {
     fn default() -> Self {
         Self::new()

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -36,6 +36,12 @@ pub struct Unit(u32);
 ///   VALUE                31-bits value that represents a value of the double array node.
 ///   IS_LEAF (I)          1-bit flag that indicates whether the node is a leaf node or not.
 ///                        This flag is always 1 in this case.
+impl Default for Unit {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Unit {
     /// Creates a new Unit.
     #[inline]
@@ -96,12 +102,12 @@ impl Unit {
 
         if offset < (1u32 << 21) {
             // don't extend offset
-            self.0 = offset << 10 | (self.0 << 23 as u32) >> 23;
+            self.0 = offset << 10 | (self.0 << 23_u32) >> 23;
         } else {
             // extend offset
             assert_eq!((offset << 2) & (1 << 31), 0, "MSB of offset should be 0");
             assert_eq!(offset & 0xFF, 0, "lower 8 bits of offset should be 0");
-            self.0 = offset << 2 | (1 << 9) | (self.0 << 23 as u32) >> 23; // with offset extension flag
+            self.0 = offset << 2 | (1 << 9) | (self.0 << 23_u32) >> 23; // with offset extension flag
         }
     }
 
@@ -126,16 +132,16 @@ impl Unit {
     pub fn set_value(&mut self, value: u32) {
         self.0 = value | 1 << 31
     }
+}
 
-    /// Returns a string representation of the unit.
-    pub fn to_string(&self) -> String {
+impl std::fmt::Display for Unit {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         if self.is_leaf() {
-            // leaf node
-            format!("Unit {{ value: {} }}", self.value()).to_string()
+            write!(f, "Unit {{ value: {} }}", self.value())
         } else {
-            // internal node
             let label = self.label();
-            format!(
+            write!(
+                f,
                 "Unit {{ offset: {}, label: {}, has_leaf: {} }}",
                 self.offset(),
                 match label {
@@ -145,14 +151,13 @@ impl Unit {
                 },
                 self.has_leaf()
             )
-            .to_string()
         }
     }
 }
 
 impl std::fmt::Debug for Unit {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.to_string())
+        write!(f, "{}", self)
     }
 }
 


### PR DESCRIPTION
## Summary
Add a CI workflow that runs on every push to `master` and on PRs.

### Jobs
- **test** — `cargo test --workspace` on ubuntu / ubuntu-24.04-arm / macos / windows
- **fmt** — `cargo fmt --all --check`
- **clippy** — `cargo clippy --workspace --all-targets -- -D warnings`
- **doc** — `cargo doc -p yada --no-deps` with `RUSTDOCFLAGS=-D warnings` (catches broken intra-doc links)
- **msrv** — `cargo check -p yada` on the declared MSRV toolchain

### Workflow hygiene
- `permissions: contents: read` — restrict `GITHUB_TOKEN` to the minimum
- `concurrency` with `cancel-in-progress` — cancel superseded runs on the same ref
- `timeout-minutes` per job — avoid runaway runs
- `Swatinem/rust-cache@v2` — cache cargo artifacts

### MSRV
- Set `rust-version = "1.58.0"` in `Cargo.toml`
- 1.58 is the actual minimum (limited by captured-identifier format strings `{max}` in `errors.rs`, stabilized in Rust 1.58)
- The `msrv` job verifies this in CI

### Code changes (no logic changes, all clippy-driven)
- Add `Default` impls for `DoubleArrayBuilder` and `Unit`
- Replace `assert!(false, ...)` with `panic!(...)`
- Move `Unit::to_string` to a `Display` impl
- Move `Unit` bit-layout doc to the type definition
- Misc lints: `Self(x)`, `is_empty`, redundant casts, `.next()` instead of `.nth(0)`

The release/publish workflow is split into a separate PR (#37).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (13 passed)
- [x] `cargo +1.58.0 check -p yada`
- [x] CI green on all 8 checks (test ×4, fmt, clippy, doc, msrv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
