### PR TITLE
Add release workflow with crates.io publishing and GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ permissions:
 
 concurrency:
   group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
@@ -27,7 +28,7 @@ jobs:
       - name: Verify tag matches Cargo.toml version
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          if ! grep -q "^version = \"${VERSION}\"$" Cargo.toml; then
+          if ! grep -qxF "version = \"${VERSION}\"" Cargo.toml; then
             echo "Tag ${VERSION} does not match Cargo.toml version:" >&2
             grep "^version =" Cargo.toml >&2
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test -p yada
       - uses: rust-lang/crates-io-auth-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,19 +7,61 @@ on:
       - "[0-9]+.[0-9]+.[0-9]+"
       - "[0-9]+.[0-9]+.[0-9]+-*"
 
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: release
-    permissions:
-      id-token: write
-      contents: read
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches Cargo.toml version
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          if ! grep -q "^version = \"${VERSION}\"$" Cargo.toml; then
+            echo "Tag ${VERSION} does not match Cargo.toml version:" >&2
+            grep "^version =" Cargo.toml >&2
+            exit 1
+          fi
+
+      - name: Extract CHANGELOG section for this version
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { flag=1; next }
+            flag && /^## \[/ { exit }
+            flag { print }
+          ' CHANGELOG.md > release_notes.md
+          if [ ! -s release_notes.md ]; then
+            echo "No CHANGELOG.md section found for [${VERSION}]" >&2
+            exit 1
+          fi
+          echo "---- release notes ----"
+          cat release_notes.md
+
       - run: cargo test -p yada
+
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
+
       - run: cargo publish -p yada
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file release_notes.md \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      # SemVer 2.0.0 subset (no v prefix)
+      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]+.[0-9]+.[0-9]+-*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo test -p yada
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+      - run: cargo publish -p yada
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ compact data representation.
 
 ## Requirements
 
-- Rust version >= 1.46.0 
+- Rust version >= 1.58.0
 
 ## Usage
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,52 @@
+# Releasing yada
+
+This document is for maintainers cutting a new release.
+
+## Prerequisites (one-time)
+
+- crates.io Trusted Publishing configured for this repo:
+  Owner `takuyaa` / Repo `yada` / Workflow `release.yml` / Environment `release`
+  (Crate Settings → Trusted Publishing on crates.io)
+
+## Release procedure
+
+1. Decide the new version `X.Y.Z` following [SemVer](https://semver.org/).
+   Optionally run `cargo semver-checks check-release` to detect API breakage.
+2. Update `CHANGELOG.md`:
+   - Replace `## [Unreleased]` with `## [X.Y.Z] - YYYY-MM-DD`
+   - Add a new empty `## [Unreleased]` above
+   - Add a new comparison link at the bottom and update the `[Unreleased]` link
+3. Update `version` in `Cargo.toml` to `X.Y.Z`.
+4. Commit and push to `master`:
+
+   ```
+   git commit -am "Release X.Y.Z"
+   git push
+   ```
+5. Tag and push:
+
+   ```
+   git tag X.Y.Z
+   git push --tags
+   ```
+6. The `Release` workflow will:
+   - Verify the tag matches `Cargo.toml`
+   - Extract the matching `CHANGELOG.md` section as release notes
+   - Run tests, then `cargo publish` via Trusted Publishing
+   - Create the GitHub Release
+7. Verify the published version appears on
+   <https://crates.io/crates/yada> and the GitHub Release page.
+
+## Recovering from a failed release
+
+- **Publish failed before the tag was used**: fix the issue on `master`,
+  delete the tag locally and on the remote, then recreate it:
+
+  ```
+  git push --delete origin X.Y.Z
+  git tag -d X.Y.Z
+  ```
+- **`CHANGELOG.md` section missing for the tag**: the workflow aborts before
+  publishing. Add the section, recreate the tag.
+- **Already published to crates.io**: crates.io versions are immutable.
+  Yank the bad version (`cargo yank --version X.Y.Z`) and release `X.Y.Z+1`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,8 @@ This document is for maintainers cutting a new release.
 ## Release procedure
 
 1. Decide the new version `X.Y.Z` following [SemVer](https://semver.org/).
-   Optionally run `cargo semver-checks check-release` to detect API breakage.
+   Optionally run `cargo semver-checks check-release` (install with
+   `cargo install cargo-semver-checks`) to detect API breakage.
 2. Update `CHANGELOG.md`:
    - Replace `## [Unreleased]` with `## [X.Y.Z] - YYYY-MM-DD`
    - Add a new empty `## [Unreleased]` above


### PR DESCRIPTION
## Summary
Add a release workflow that publishes to crates.io **and** creates a GitHub Release from `CHANGELOG.md` when a SemVer tag is pushed (ripgrep-style). Also document the release procedure.

### Trigger
- SemVer tags without `v` prefix (matching the existing tag convention `0.5.1` etc.)
- Pattern: `[0-9]+.[0-9]+.[0-9]+` (and `-*` for prereleases)

### Workflow steps
1. **Verify tag matches `Cargo.toml` version** — fails fast on mismatch
2. **Extract CHANGELOG section** for the tag (`## [VERSION]` block) into `release_notes.md`
3. **`cargo test -p yada`** — last sanity check before publish
4. **`rust-lang/crates-io-auth-action@v1`** — get a short-lived token via Trusted Publishing (OIDC)
5. **`cargo publish -p yada`**
6. **`gh release create`** — create the GitHub Release using the extracted notes (only after publish succeeds, so failed publishes don't leave stray Releases)

### Permissions
- `contents: write` — required for `gh release create`
- `id-token: write` — required for Trusted Publishing

### Documentation
- **New `RELEASE.md`**: maintainer-facing checklist covering prerequisites, the step-by-step procedure, and recovery from failure cases.
- **`README.md`**: bump the stated MSRV from `1.46.0` to `1.58.0` to match `Cargo.toml` (added in #36).

### One-time setup required
Trusted Publishing must be configured once on crates.io (crate Settings → Trusted Publishing):
- Owner `takuyaa` / Repo `yada` / Workflow `release.yml` / Environment `release`

### Notes
- Independent of PR #36 (CI workflow). Either can be merged first.
- Validated the CHANGELOG extraction logic locally against existing `0.5.1` / `0.4.0` sections; non-existent versions correctly yield empty output and abort the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
